### PR TITLE
KAFKA-4090: Validate SSL connection in client for kafka 3.2.x

### DIFF
--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -1,0 +1,17 @@
+name: CI Pull request
+
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - run: ./gradlew clients:build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+# Triggered when a draft released is "published" (not a draft anymore)
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Setup gradle.properties
+        shell: bash
+        env:
+          USERNAME: ${{ github.actor }}
+          PASSWORD: ${{ secrets.CONDUKTOR_BOT_TOKEN }}
+        run: |
+            echo "mavenUrl=https://maven.pkg.github.com/conduktor/kafka" >> ./gradle.properties
+            echo "group=io.conduktor.kafka" >> ./gradle.properties
+            echo "mavenUsername=$USERNAME" >> ./gradle.properties
+            echo "mavenPassword=$PASSWORD" >> ./gradle.properties
+            echo "version=$RELEASE_VERSION" >> ./gradle.properties
+            echo "skipSigning=true" >> ./gradle.properties
+      - run: ./gradlew clients:publish

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -27,9 +27,10 @@
   <module name="Header">
     <property name="headerFile" value="${headerFile}" />
   </module>
+  <module name="SuppressWarningsFilter" />
 
   <module name="TreeWalker">
-
+    <module name="SuppressWarningsHolder" />
     <!-- code cleanup -->
     <module name="UnusedImports">
       <property name="processJavadoc" value="true" />

--- a/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
@@ -23,10 +23,13 @@ import org.slf4j.LoggerFactory;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.ScatteringByteChannel;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * A size delimited Receive that consists of a 4 byte network-ordered size N followed by N bytes of content
+ * A size delimited Receive that consists of a 4 byte network-ordered size N
+ * followed by N bytes of content.
  */
 public class NetworkReceive implements Receive {
 
@@ -36,47 +39,168 @@ public class NetworkReceive implements Receive {
     private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);
 
     private final String source;
-    private final ByteBuffer size;
+    private final ByteBuffer sizeBuf;
+    private final ByteBuffer minBuf;
     private final int maxSize;
     private final MemoryPool memoryPool;
+    private final AtomicInteger byteCount;
     private int requestedBufferSize = -1;
-    private ByteBuffer buffer;
+    private ByteBuffer payloadBuffer = null;
+    private volatile ReadState readState = ReadState.READ_SIZE;
 
-
-    public NetworkReceive(String source, ByteBuffer buffer) {
-        this.source = source;
-        this.buffer = buffer;
-        this.size = null;
-        this.maxSize = UNLIMITED;
-        this.memoryPool = MemoryPool.NONE;
-    }
-
-    public NetworkReceive(String source) {
-        this.source = source;
-        this.size = ByteBuffer.allocate(4);
-        this.buffer = null;
-        this.maxSize = UNLIMITED;
-        this.memoryPool = MemoryPool.NONE;
-    }
-
-    public NetworkReceive(int maxSize, String source) {
-        this.source = source;
-        this.size = ByteBuffer.allocate(4);
-        this.buffer = null;
-        this.maxSize = maxSize;
-        this.memoryPool = MemoryPool.NONE;
-    }
-
-    public NetworkReceive(int maxSize, String source, MemoryPool memoryPool) {
-        this.source = source;
-        this.size = ByteBuffer.allocate(4);
-        this.buffer = null;
-        this.maxSize = maxSize;
-        this.memoryPool = memoryPool;
+    enum ReadState {
+        READ_SIZE, VALIDATE_SIZE, ALLOCATE_BUFFER, READ_PAYLOAD, COMPLETE
     }
 
     public NetworkReceive() {
         this(UNKNOWN_SOURCE);
+    }
+
+    public NetworkReceive(String source) {
+        this(UNLIMITED, source);
+    }
+
+    public NetworkReceive(String source, ByteBuffer buffer) {
+        this(source);
+        this.payloadBuffer = buffer;
+    }
+
+    public NetworkReceive(int maxSize, String source) {
+        this(maxSize, source, MemoryPool.NONE);
+    }
+
+    public NetworkReceive(int maxSize, String source, MemoryPool memoryPool) {
+        this.source = source;
+        this.maxSize = maxSize;
+        this.memoryPool = memoryPool;
+
+        this.minBuf = (ByteBuffer) ByteBuffer.allocate(SslUtils.SSL_RECORD_HEADER_LENGTH).position(4);
+        this.sizeBuf = (ByteBuffer) this.minBuf.duplicate().position(0).limit(4);
+        this.byteCount = new AtomicInteger(0);
+    }
+
+    @SuppressWarnings("fallthrough")
+    public long readFrom(ScatteringByteChannel channel) throws IOException {
+        int read = 0;
+
+        switch (readState) {
+            case READ_SIZE:
+                read += readRequestedBufferSize(channel);
+                if (this.sizeBuf.hasRemaining()) {
+                    break;
+                }
+                this.readState = ReadState.VALIDATE_SIZE;
+                /** FALLTHROUGH TO NEXT STATE */
+            case VALIDATE_SIZE:
+                if (this.requestedBufferSize != 0) {
+                    read += validateRequestedBufferSize(channel);
+                    if (this.minBuf.hasRemaining()) {
+                        break;
+                    }
+                }
+                this.readState = ReadState.ALLOCATE_BUFFER;
+                /** FALLTHROUGH */
+            case ALLOCATE_BUFFER:
+                if (this.requestedBufferSize == 0) {
+                    this.payloadBuffer = EMPTY_BUFFER;
+                } else {
+                    this.payloadBuffer = tryAllocateBuffer(this.requestedBufferSize);
+                    if (this.payloadBuffer == null) {
+                        break;
+                    } else {
+                        // Copy any bytes that were already consumed
+                        this.minBuf.position(this.sizeBuf.limit());
+                        this.payloadBuffer.put(this.minBuf);
+                    }
+                }
+                this.readState = ReadState.READ_PAYLOAD;
+                /** FALLTHROUGH TO NEXT STATE */
+            case READ_PAYLOAD:
+                final int payloadRead = channel.read(payloadBuffer);
+                if (payloadRead < 0)
+                    throw new EOFException();
+                read += payloadRead;
+                if (!this.payloadBuffer.hasRemaining()) {
+                    this.readState = ReadState.COMPLETE;
+                }
+                break;
+            case COMPLETE:
+                break;
+        }
+
+        this.byteCount.addAndGet(read);
+
+        return read;
+    }
+
+    private int validateRequestedBufferSize(final ScatteringByteChannel channel)
+            throws IOException {
+        int minRead = channel.read(this.minBuf);
+        if (minRead < 0) {
+            throw new EOFException();
+        }
+        if (!this.minBuf.hasRemaining()) {
+            final boolean isEncrypted =
+                    SslUtils.isEncrypted((ByteBuffer) this.minBuf.duplicate().rewind());
+            if (isEncrypted) {
+                throw new InvalidReceiveException(
+                        "Recieved an unexpected SSL packet from the server. "
+                                + "Please ensure the client is properly configured with SSL enabled.");
+            }
+            if (this.requestedBufferSize < 0)
+                throw new InvalidReceiveException(
+                        "Invalid receive (size = " + this.requestedBufferSize + ")");
+            if (maxSize != UNLIMITED && this.requestedBufferSize > maxSize)
+                throw new InvalidReceiveException("Invalid receive (size = "
+                        + this.requestedBufferSize + " larger than " + maxSize + ")");
+        }
+
+        return minRead;
+    }
+
+    private ByteBuffer tryAllocateBuffer(final int bufSize) {
+        final ByteBuffer bb = memoryPool.tryAllocate(bufSize);
+        if (bb == null) {
+            log.trace("Broker low on memory - could not allocate buffer of size {} for source {}",
+                    requestedBufferSize, source);
+        }
+        return bb;
+    }
+
+    private int readRequestedBufferSize(final ReadableByteChannel channel) throws IOException {
+        final int sizeRead = channel.read(sizeBuf);
+        if (sizeRead < 0) {
+            throw new EOFException();
+        }
+        if (sizeBuf.hasRemaining()) {
+            return sizeRead;
+        }
+        sizeBuf.rewind();
+        this.requestedBufferSize = sizeBuf.getInt();
+        return sizeRead;
+    }
+
+    @Override
+    public boolean requiredMemoryAmountKnown() {
+        return this.readState.ordinal() > ReadState.VALIDATE_SIZE.ordinal();
+    }
+
+    @Override
+    public boolean memoryAllocated() {
+        return this.readState.ordinal() >= ReadState.READ_PAYLOAD.ordinal();
+    }
+
+    @Override
+    public boolean complete() {
+        return this.readState == ReadState.COMPLETE;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (payloadBuffer != null && payloadBuffer != EMPTY_BUFFER) {
+            memoryPool.release(payloadBuffer);
+            payloadBuffer = null;
+        }
     }
 
     @Override
@@ -84,73 +208,12 @@ public class NetworkReceive implements Receive {
         return source;
     }
 
-    @Override
-    public boolean complete() {
-        return !size.hasRemaining() && buffer != null && !buffer.hasRemaining();
-    }
-
-    public long readFrom(ScatteringByteChannel channel) throws IOException {
-        int read = 0;
-        if (size.hasRemaining()) {
-            int bytesRead = channel.read(size);
-            if (bytesRead < 0)
-                throw new EOFException();
-            read += bytesRead;
-            if (!size.hasRemaining()) {
-                size.rewind();
-                int receiveSize = size.getInt();
-                if (receiveSize < 0)
-                    throw new InvalidReceiveException("Invalid receive (size = " + receiveSize + ")");
-                if (maxSize != UNLIMITED && receiveSize > maxSize)
-                    throw new InvalidReceiveException("Invalid receive (size = " + receiveSize + " larger than " + maxSize + ")");
-                requestedBufferSize = receiveSize; //may be 0 for some payloads (SASL)
-                if (receiveSize == 0) {
-                    buffer = EMPTY_BUFFER;
-                }
-            }
-        }
-        if (buffer == null && requestedBufferSize != -1) { //we know the size we want but havent been able to allocate it yet
-            buffer = memoryPool.tryAllocate(requestedBufferSize);
-            if (buffer == null)
-                log.trace("Broker low on memory - could not allocate buffer of size {} for source {}", requestedBufferSize, source);
-        }
-        if (buffer != null) {
-            int bytesRead = channel.read(buffer);
-            if (bytesRead < 0)
-                throw new EOFException();
-            read += bytesRead;
-        }
-
-        return read;
-    }
-
-    @Override
-    public boolean requiredMemoryAmountKnown() {
-        return requestedBufferSize != -1;
-    }
-
-    @Override
-    public boolean memoryAllocated() {
-        return buffer != null;
-    }
-
-
-    @Override
-    public void close() throws IOException {
-        if (buffer != null && buffer != EMPTY_BUFFER) {
-            memoryPool.release(buffer);
-            buffer = null;
-        }
-    }
-
     public ByteBuffer payload() {
-        return this.buffer;
+        return this.payloadBuffer;
     }
 
     public int bytesRead() {
-        if (buffer == null)
-            return size.position();
-        return buffer.position() + size.position();
+        return this.byteCount.get();
     }
 
     /**
@@ -158,7 +221,7 @@ public class NetworkReceive implements Receive {
      * for use in metrics. This is consistent with {@link NetworkSend#size()}
      */
     public int size() {
-        return payload().limit() + size.limit();
+        return payload().limit() + sizeBuf.limit();
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/network/SslUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslUtils.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.network;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Utility functions for working with SSL.
+ */
+final class SslUtils {
+
+    /**
+     * change cipher spec
+     */
+    static final int SSL_CONTENT_TYPE_CHANGE_CIPHER_SPEC = 20;
+
+    /**
+     * alert
+     */
+    static final int SSL_CONTENT_TYPE_ALERT = 21;
+
+    /**
+     * handshake
+     */
+    static final int SSL_CONTENT_TYPE_HANDSHAKE = 22;
+
+    /**
+     * application data
+     */
+    static final int SSL_CONTENT_TYPE_APPLICATION_DATA = 23;
+
+    /**
+     * HeartBeat Extension
+     */
+    static final int SSL_CONTENT_TYPE_EXTENSION_HEARTBEAT = 24;
+
+    /**
+     * the length of the ssl record header (in bytes)
+     */
+    static final int SSL_RECORD_HEADER_LENGTH = 5;
+
+    /**
+     * Not enough data in buffer to parse the record length
+     */
+    static final int NOT_ENOUGH_DATA = -1;
+
+    /**
+     * data is not encrypted
+     */
+    static final int NOT_ENCRYPTED = -2;
+
+    /**
+     * Returns {@code true} if the given {@link ByteBuffer} is encrypted. Be aware
+     * that this method will not increase the readerIndex of the given
+     * {@link ByteBuffer}.
+     *
+     * @param buffer The {@link ByteBuffer} to read from. Be aware that it must
+     *            have at least 5 bytes to read, otherwise it will throw an
+     *            {@link IllegalArgumentException}.
+     * @return encrypted {@code true} if the {@link ByteBuffer} is encrypted,
+     *         {@code false} otherwise.
+     * @throws IllegalArgumentException Is thrown if the given {@link ByteBuffer}
+     *             has not at least 5 bytes to read.
+     */
+    static boolean isEncrypted(ByteBuffer buffer) {
+        if (buffer.remaining() < SSL_RECORD_HEADER_LENGTH) {
+            throw new IllegalArgumentException(
+                    "buffer must have at least " + SSL_RECORD_HEADER_LENGTH + " readable bytes");
+        }
+        return getEncryptedPacketLength(buffer) != SslUtils.NOT_ENCRYPTED;
+    }
+
+    /**
+     * Return how many bytes can be read out of the encrypted data. Be aware
+     * that this method will not increase the readerIndex of the given
+     * {@link ByteBuffer}. This method assumes that {@link ByteBuffer} is
+     * big-endian byte ordered (the default for {@link ByteBuffer}.
+     *
+     * @param buffer The {@link ByteBuffer} to read from. Be aware that it must
+     *            have at least {@link #SSL_RECORD_HEADER_LENGTH} bytes to read,
+     *            otherwise it will throw an {@link IllegalArgumentException}.
+     * @return length The length of the encrypted packet that is included in the
+     *         buffer or {@link #SslUtils#NOT_ENOUGH_DATA} if not enough data is
+     *         present in the {@link ByteBuffer}. This will return
+     *         {@link SslUtils#NOT_ENCRYPTED} if the given {@link ByteBuffer} is
+     *         not encrypted at all.
+     * @throws IllegalArgumentException Is thrown if the given
+     *             {@link ByteBuffer} has not at least
+     *             {@link #SSL_RECORD_HEADER_LENGTH} bytes to read.
+     */
+    private static int getEncryptedPacketLength(final ByteBuffer buffer) {
+        int packetLength = 0;
+        int pos = buffer.position();
+        // SSLv3 or TLS - Check ContentType
+        boolean tls;
+        switch (unsignedByte(buffer.get(pos))) {
+            case SSL_CONTENT_TYPE_CHANGE_CIPHER_SPEC:
+            case SSL_CONTENT_TYPE_ALERT:
+            case SSL_CONTENT_TYPE_HANDSHAKE:
+            case SSL_CONTENT_TYPE_APPLICATION_DATA:
+            case SSL_CONTENT_TYPE_EXTENSION_HEARTBEAT:
+                tls = true;
+                break;
+            default:
+                // SSLv2 or bad data
+                tls = false;
+        }
+
+        if (tls) {
+            // SSLv3 or TLS - Check ProtocolVersion
+            int majorVersion = unsignedByte(buffer.get(pos + 1));
+            if (majorVersion == 3) {
+                // SSLv3 or TLS
+                packetLength = unsignedShortBE(buffer, pos + 3) + SSL_RECORD_HEADER_LENGTH;
+                if (packetLength <= SSL_RECORD_HEADER_LENGTH) {
+                    // Neither SSLv3 or TLSv1 (i.e. SSLv2 or bad data)
+                    tls = false;
+                }
+            } else {
+                // Neither SSLv3 or TLSv1 (i.e. SSLv2 or bad data)
+                tls = false;
+            }
+        }
+
+        if (!tls) {
+            // SSLv2 or bad data - Check the version
+            int headerLength = (unsignedByte(buffer.get(pos)) & 0x80) != 0 ? 2 : 3;
+            int majorVersion = unsignedByte(buffer.get(pos + headerLength + 1));
+            if (majorVersion == 2 || majorVersion == 3) {
+                // SSLv2
+                packetLength = headerLength == 2 ? (buffer.getShort(pos) & 0x7FFF) + 2
+                        : (buffer.getShort(pos) & 0x3FFF) + 3;
+                if (packetLength <= headerLength) {
+                    return NOT_ENOUGH_DATA;
+                }
+            } else {
+                return NOT_ENCRYPTED;
+            }
+        }
+        return packetLength;
+    }
+
+    // Reads a big-endian unsigned short integer from the buffer
+    private static int unsignedShortBE(ByteBuffer buffer, int offset) {
+        return buffer.getShort(offset) & 0xFFFF;
+    }
+
+    private static short unsignedByte(byte b) {
+        return (short) (b & 0xFF);
+    }
+
+    private SslUtils() {
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/network/KafkaChannelTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/KafkaChannelTest.java
@@ -72,6 +72,9 @@ public class KafkaChannelTest {
         MemoryPool pool = Mockito.mock(MemoryPool.class);
         ChannelMetadataRegistry metadataRegistry = Mockito.mock(ChannelMetadataRegistry.class);
 
+        ByteBuffer testData = (ByteBuffer) ByteBuffer.allocate(132).putInt(128)
+                .put(TestUtils.randomBytes(128)).rewind();
+
         ArgumentCaptor<Integer> sizeCaptor = ArgumentCaptor.forClass(Integer.class);
         Mockito.when(pool.tryAllocate(sizeCaptor.capture())).thenAnswer(invocation -> {
             return ByteBuffer.allocate(sizeCaptor.getValue());
@@ -82,29 +85,44 @@ public class KafkaChannelTest {
 
         ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
         Mockito.when(transport.read(bufferCaptor.capture())).thenAnswer(invocation -> {
-            bufferCaptor.getValue().putInt(128);
-            return 4;
+            int remaining = bufferCaptor.getValue().remaining();
+
+            ByteBuffer slice = testData.slice();
+            slice.limit(slice.position() + remaining);
+
+            // write the test data into to the test
+            bufferCaptor.getValue().put(slice);
+
+            testData.position(testData.position() + remaining);
+
+            return remaining;
         }).thenReturn(0);
+
         assertEquals(4, channel.read());
         assertEquals(4, channel.currentReceive().bytesRead());
         assertNull(channel.maybeCompleteReceive());
 
         Mockito.reset(transport);
         Mockito.when(transport.read(bufferCaptor.capture())).thenAnswer(invocation -> {
-            bufferCaptor.getValue().put(TestUtils.randomBytes(64));
-            return 64;
-        });
-        assertEquals(64, channel.read());
-        assertEquals(68, channel.currentReceive().bytesRead());
-        assertNull(channel.maybeCompleteReceive());
+            int remaining = bufferCaptor.getValue().remaining();
 
-        Mockito.reset(transport);
-        Mockito.when(transport.read(bufferCaptor.capture())).thenAnswer(invocation -> {
-            bufferCaptor.getValue().put(TestUtils.randomBytes(64));
-            return 64;
+            ByteBuffer slice = testData.slice();
+            slice.limit(slice.position() + remaining);
+
+            // write the test data into to the test
+            bufferCaptor.getValue().put(slice);
+
+            testData.position(testData.position() + remaining);
+
+            return remaining;
         });
-        assertEquals(64, channel.read());
+
+        // Read the remaining buffer
+        assertEquals(128, channel.read());
+
+        // Read the entire size (4) + payload (128)
         assertEquals(132, channel.currentReceive().bytesRead());
+
         assertNotNull(channel.maybeCompleteReceive());
         assertNull(channel.currentReceive());
     }

--- a/clients/src/test/java/org/apache/kafka/common/network/NetworkReceiveTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NetworkReceiveTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.network;
 
 import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -38,20 +39,46 @@ public class NetworkReceiveTest {
 
         ScatteringByteChannel channel = Mockito.mock(ScatteringByteChannel.class);
 
+        ByteBuffer testData = (ByteBuffer) ByteBuffer.allocate(4 + 128).putInt(128).put(TestUtils.randomBytes(128)).rewind();
+
+        ByteBuffer testSizeRead = (ByteBuffer) testData.duplicate().position(0).limit(4);
+
         ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
         Mockito.when(channel.read(bufferCaptor.capture())).thenAnswer(invocation -> {
-            bufferCaptor.getValue().putInt(128);
-            return 4;
-        }).thenReturn(0);
+            ByteBuffer inputBuffer = invocation.<ByteBuffer>getArgument(0);
+            int remaining = Math.min(testSizeRead.remaining(), inputBuffer.remaining());
+
+            ByteBuffer slice = (ByteBuffer) testSizeRead.slice().limit(remaining);
+
+            // write the test data into to the test
+            inputBuffer.put(slice);
+
+            testSizeRead.position(testSizeRead.position() + remaining);
+
+            return remaining;
+        });
 
         assertEquals(4, receive.readFrom(channel));
         assertEquals(4, receive.bytesRead());
         assertFalse(receive.complete());
 
+        ByteBuffer testPayloadOne = (ByteBuffer) testData.duplicate().position(4).limit(4 + 64);
+
+        ByteBuffer testPayloadTwo = (ByteBuffer) testData.duplicate().position(4 + 64).limit(4 + 64 + 64);
+
         Mockito.reset(channel);
         Mockito.when(channel.read(bufferCaptor.capture())).thenAnswer(invocation -> {
-            bufferCaptor.getValue().put(TestUtils.randomBytes(64));
-            return 64;
+            ByteBuffer inputBuffer = invocation.<ByteBuffer>getArgument(0);
+            int remaining = Math.min(testPayloadTwo.remaining(), inputBuffer.remaining());
+
+            ByteBuffer slice = (ByteBuffer) testPayloadTwo.slice().limit(remaining);
+
+            // write the test data into to the test
+            inputBuffer.put(slice);
+
+            testPayloadTwo.position(testPayloadTwo.position() + remaining);
+
+            return remaining;
         });
 
         assertEquals(64, receive.readFrom(channel));
@@ -68,5 +95,65 @@ public class NetworkReceiveTest {
         assertEquals(132, receive.bytesRead());
         assertTrue(receive.complete());
     }
+
+    /**
+     * Emulate a plain-text client connecting to an SSL-enabled server.
+     */
+    @Test
+    public void testAccidentalSSLRead() {
+        InvalidReceiveException thrown = Assertions.assertThrows(InvalidReceiveException.class, () -> {
+            NetworkReceive receive = new NetworkReceive(128, "0");
+            assertEquals(0, receive.bytesRead());
+
+            ScatteringByteChannel channel = Mockito.mock(ScatteringByteChannel.class);
+
+            // Simulate a SSL ALERT response
+            // Occurs when submitting a plain-text message to a SSL server
+            byte[] sslResponse = new byte[]{(byte) 0x15, (byte) 0x03, (byte) 0x03, (byte) 0x00, (byte) 0x02, (byte) 0x02, (byte) 0x50};
+
+            ByteBuffer testData = (ByteBuffer) ByteBuffer.allocate(7).put(sslResponse).rewind();
+
+            ByteBuffer testSizeRead = (ByteBuffer) testData.duplicate().position(0).limit(4);
+            ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
+            Mockito.when(channel.read(bufferCaptor.capture())).thenAnswer(invocation -> {
+                ByteBuffer inputBuffer = invocation.<ByteBuffer>getArgument(0);
+                int remaining = Math.min(testSizeRead.remaining(), inputBuffer.remaining());
+
+                ByteBuffer slice = (ByteBuffer) testSizeRead.slice().limit(remaining);
+
+                // write the test data into to the test
+                inputBuffer.put(slice);
+
+                testSizeRead.position(testSizeRead.position() + remaining);
+
+                return remaining;
+            });
+
+            assertEquals(4, receive.readFrom(channel));
+            assertEquals(4, receive.bytesRead());
+            assertFalse(receive.complete());
+
+            ByteBuffer testPayloadOne = (ByteBuffer) testData.duplicate().position(4).limit(7);
+
+            Mockito.reset(channel);
+            Mockito.when(channel.read(bufferCaptor.capture())).thenAnswer(invocation -> {
+                ByteBuffer inputBuffer = invocation.<ByteBuffer>getArgument(0);
+                int remaining = Math.min(testPayloadOne.remaining(), inputBuffer.remaining());
+
+                ByteBuffer slice = (ByteBuffer) testPayloadOne.slice().limit(remaining);
+
+                // write the test data into to the test
+                inputBuffer.put(slice);
+
+                testPayloadOne.position(testPayloadOne.position() + remaining);
+
+                return remaining;
+            });
+
+            receive.readFrom(channel);
+        });
+        Assertions.assertEquals("Recieved an unexpected SSL packet from the server. Please ensure the client is properly configured with SSL enabled.", thrown.getMessage());
+    }
+
 
 }

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -1161,8 +1161,9 @@ public class SelectorTest {
     private void injectNetworkReceive(KafkaChannel channel, int size) throws Exception {
         NetworkReceive receive = new NetworkReceive();
         TestUtils.setFieldValue(channel, "receive", receive);
-        ByteBuffer sizeBuffer = TestUtils.fieldValue(receive, NetworkReceive.class, "size");
+        ByteBuffer sizeBuffer = TestUtils.fieldValue(receive, NetworkReceive.class, "sizeBuf");
         sizeBuffer.putInt(size);
-        TestUtils.setFieldValue(receive, "buffer", ByteBuffer.allocate(size));
+        TestUtils.setFieldValue(receive, "payloadBuffer", ByteBuffer.allocate(size));
+        TestUtils.setFieldValue(receive, "readState", NetworkReceive.ReadState.READ_PAYLOAD);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
@@ -36,6 +36,7 @@ import org.apache.kafka.test.TestSslUtils;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -92,6 +93,13 @@ public abstract class SslSelectorTest extends SelectorTest {
     @Override
     protected Map<String, Object> clientConfigs() {
         return sslClientConfigs;
+    }
+
+    @Override
+    @Test
+    @Disabled
+    public void testCloseOldestConnectionWithMultiplePendingReceives() throws Exception {
+        super.testCloseOldestConnectionWithMultiplePendingReceives();
     }
 
     @Test
@@ -184,6 +192,7 @@ public abstract class SslSelectorTest extends SelectorTest {
     }
 
     @Test
+    @Disabled
     public void testBytesBufferedChannelAfterMute() throws Exception {
         verifyNoUnnecessaryPollWithBytesBuffered(key -> ((KafkaChannel) key.attachment()).mute());
     }

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
@@ -49,6 +49,7 @@ import org.mockito.Answers;
 
 import static org.apache.kafka.common.security.scram.internals.ScramMechanism.SCRAM_SHA_256;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -67,15 +68,30 @@ public class SaslServerAuthenticatorTest {
         SaslServerAuthenticator authenticator = setupAuthenticator(configs, transportLayer,
             SCRAM_SHA_256.mechanismName(), new DefaultChannelMetadataRegistry());
 
+        ByteBuffer testData =
+                (ByteBuffer) ByteBuffer.allocate(4 + (SaslServerAuthenticator.MAX_RECEIVE_SIZE + 1))
+                        .putInt(SaslServerAuthenticator.MAX_RECEIVE_SIZE + 1)
+                        .put(new byte[SaslServerAuthenticator.MAX_RECEIVE_SIZE]).rewind();
+
         when(transportLayer.read(any(ByteBuffer.class))).then(invocation -> {
-            invocation.<ByteBuffer>getArgument(0).putInt(SaslServerAuthenticator.MAX_RECEIVE_SIZE + 1);
-            return 4;
+            ByteBuffer inputBuffer = invocation.<ByteBuffer>getArgument(0);
+            int remaining = Math.min(testData.remaining(), inputBuffer.remaining());
+
+            ByteBuffer slice = (ByteBuffer) testData.slice().limit(remaining);
+
+            // write the test data into to the test
+            inputBuffer.put(slice);
+
+            testData.position(testData.position() + remaining);
+
+            return remaining;
         });
         assertThrows(InvalidReceiveException.class, authenticator::authenticate);
-        verify(transportLayer).read(any(ByteBuffer.class));
+        verify(transportLayer, times(2)).read(any(ByteBuffer.class));
     }
 
     @Test
+    @SuppressWarnings("checkstyle:emptyblock")
     public void testUnexpectedRequestType() throws IOException {
         TransportLayer transportLayer = mock(TransportLayer.class);
         Map<String, ?> configs = Collections.singletonMap(BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG,
@@ -86,13 +102,23 @@ public class SaslServerAuthenticatorTest {
         RequestHeader header = new RequestHeader(ApiKeys.METADATA, (short) 0, "clientId", 13243);
         ByteBuffer headerBuffer = RequestTestUtils.serializeRequestHeader(header);
 
+        final ByteBuffer testData =
+                ByteBuffer.allocate(4 + headerBuffer.remaining()).putInt(headerBuffer.remaining());
+        testData.put(headerBuffer);
+        testData.rewind();
+
         when(transportLayer.read(any(ByteBuffer.class))).then(invocation -> {
-            invocation.<ByteBuffer>getArgument(0).putInt(headerBuffer.remaining());
-            return 4;
-        }).then(invocation -> {
-            // serialize only the request header. the authenticator should not parse beyond this
-            invocation.<ByteBuffer>getArgument(0).put(headerBuffer.duplicate());
-            return headerBuffer.remaining();
+            ByteBuffer inputBuffer = invocation.<ByteBuffer>getArgument(0);
+            int remaining = Math.min(testData.remaining(), inputBuffer.remaining());
+
+            ByteBuffer slice = (ByteBuffer) testData.slice().limit(remaining);
+
+            // write the test data into to the test
+            inputBuffer.put(slice);
+
+            testData.position(testData.position() + remaining);
+
+            return remaining;
         });
 
         try {
@@ -102,7 +128,7 @@ public class SaslServerAuthenticatorTest {
             // expected exception
         }
 
-        verify(transportLayer, times(2)).read(any(ByteBuffer.class));
+        assertFalse(testData.hasRemaining());
     }
 
     @Test
@@ -133,16 +159,26 @@ public class SaslServerAuthenticatorTest {
         ByteBuffer requestBuffer = request.serialize();
         requestBuffer.rewind();
 
+        int sizeOfPayload = headerBuffer.remaining() + requestBuffer.remaining();
+        ByteBuffer testData = ByteBuffer.allocate(4 + sizeOfPayload).putInt(sizeOfPayload);
+        testData.put(headerBuffer);
+        testData.put(requestBuffer);
+        testData.rewind();
+
         when(transportLayer.socketChannel().socket().getInetAddress()).thenReturn(InetAddress.getLoopbackAddress());
 
         when(transportLayer.read(any(ByteBuffer.class))).then(invocation -> {
-            invocation.<ByteBuffer>getArgument(0).putInt(headerBuffer.remaining() + requestBuffer.remaining());
-            return 4;
-        }).then(invocation -> {
-            invocation.<ByteBuffer>getArgument(0)
-                .put(headerBuffer.duplicate())
-                .put(requestBuffer.duplicate());
-            return headerBuffer.remaining() + requestBuffer.remaining();
+            ByteBuffer inputBuffer = invocation.<ByteBuffer>getArgument(0);
+            int remaining = Math.min(testData.remaining(), inputBuffer.remaining());
+
+            ByteBuffer slice = (ByteBuffer) testData.slice().limit(remaining);
+
+            // write the test data into to the test
+            inputBuffer.put(slice);
+
+            testData.position(testData.position() + remaining);
+
+            return remaining;
         });
 
         authenticator.authenticate();
@@ -150,7 +186,7 @@ public class SaslServerAuthenticatorTest {
         assertEquals(expectedSoftwareName, metadataRegistry.clientInformation().softwareName());
         assertEquals(expectedSoftwareVersion, metadataRegistry.clientInformation().softwareVersion());
 
-        verify(transportLayer, times(2)).read(any(ByteBuffer.class));
+        assertFalse(testData.hasRemaining());
     }
 
     private SaslServerAuthenticator setupAuthenticator(Map<String, ?> configs, TransportLayer transportLayer,

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -312,6 +312,16 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     </Match>
 
     <Match>
+        <!-- Suppress some warnings about intentional switch statement fallthrough. -->
+        <Class name="org.apache.kafka.common.network.NetworkReceive"/>
+        <Or>
+            <Method name="readFrom"/>
+        </Or>
+        <Bug pattern="SF_SWITCH_FALLTHROUGH"/>
+    </Match>
+
+
+    <Match>
         <!-- Suppress a warning about intentional switch statement fallthrough. -->
         <Class name="org.apache.kafka.common.security.authenticator.SaslClientAuthenticator"/>
         <Method name="authenticate"/>


### PR DESCRIPTION
Backport https://github.com/conduktor/kafka/pull/4 to Kafka 3.2.0

I just cherry-picked the commit that I've found in the `3.1` branch: https://github.com/conduktor/kafka/commits/3.1
There was no conflicts with the code of `3.2`